### PR TITLE
Nmode cell array to mat

### DIFF
--- a/matlab/code/helpers/cell_array_to_nd_array.m
+++ b/matlab/code/helpers/cell_array_to_nd_array.m
@@ -1,0 +1,17 @@
+function Xs_array = cell_array_to_nd_array(Xs_cell_array)
+    n_tensors = length(Xs_cell_array);
+    obs_dimensions = size(Xs_cell_array{1});
+    n_observation_modes = length(obs_dimensions);
+    
+    
+    cell_as_mat = cell2mat(Xs_cell_array);
+
+    reshaped_mat = reshape(cell_as_mat, [obs_dimensions, n_tensors]);
+    
+    %permute_vector = [1:(n_observation_modes-1), n_observation_modes+1, n_observation_modes];
+    permute_vector = [1:2, 4:(n_observation_modes+1), 3];
+
+    permuted_mat_obs_in_last_mode = permute(reshaped_mat, permute_vector);
+    
+    Xs_array = permuted_mat_obs_in_last_mode;
+end

--- a/matlab/code/helpers/cell_array_to_nd_array.m
+++ b/matlab/code/helpers/cell_array_to_nd_array.m
@@ -1,4 +1,19 @@
 function Xs_array = cell_array_to_nd_array(Xs_cell_array)
+% Xs_array = cell_array_to_nd_array(Xs_cell_array)
+%
+% Arrange n-mode arrays from cell array in (n+1)-mode array.
+%
+% Each n-mode array in the input 'Xs_cell_array' must have the same
+% dimensions. An n-mode array with observations along the (n+1)'th mode
+% is returned.
+%
+% Input:
+%
+% Xs_cell_array: Cell array containing numeric arrays of equal dimensions.
+%
+% Output:
+%
+% Xs_array: Numeric array with observations along last dimension.
     n_tensors = length(Xs_cell_array);
     obs_dimensions = size(Xs_cell_array{1});
     n_observation_modes = length(obs_dimensions);
@@ -8,7 +23,6 @@ function Xs_array = cell_array_to_nd_array(Xs_cell_array)
 
     reshaped_mat = reshape(cell_as_mat, [obs_dimensions, n_tensors]);
     
-    %permute_vector = [1:(n_observation_modes-1), n_observation_modes+1, n_observation_modes];
     permute_vector = [1:2, 4:(n_observation_modes+1), 3];
 
     permuted_mat_obs_in_last_mode = permute(reshaped_mat, permute_vector);

--- a/matlab/code/tensor_classification/CMDA.m
+++ b/matlab/code/tensor_classification/CMDA.m
@@ -1,7 +1,13 @@
 function [Us, iit, errs, objfuncvals, objfuncvals_traceratio, Ys] = CMDA(Xs, classes, varargin)
 % [Us, iit, errs, objfuncvals, Ys] = CMDA(Xs, classes, varargin)
+%
+% Use CMDA to find projection matrices for each mode of the input data in Xs.
+% Xs is assumed to be a cell array, with each entry containing an
+% n-dimensional observation tensor.
+%
 % Mandatory input:
-% Xs:           Cell array containing the observed tensors.
+% Xs:           Cell array containing the observed tensors or array with 
+%               observations along last dimension.
 % classes:      Vector containing class labels. Classes must be sequential
 %               numbers starting from one.
 %
@@ -41,15 +47,17 @@ function [Us, iit, errs, objfuncvals, objfuncvals_traceratio, Ys] = CMDA(Xs, cla
 %   IEEE Transactions on Pattern Analysis and Machine Intelligence
 
 %% read input and set parameters
+
+if isa(Xs, 'cell')
+    Xs = cell_array_to_nd_array(Xs);
+    % Xs = reshape(cell2mat(classmeandiffs), I, J, nclasses);
+end
+    
+
 Xsample1 = Xs{1};
 sizeX = size(Xsample1);
 tol=1e-6;
-nmodes = 2;
-
-if length(sizeX) > 2
-    error(['CMDA.m: Input data has more than two dimensions. '...
-        'This function is only customised for two-dimensional (i.e. matrix) data.'])
-end
+nmodes = length(sizeX);
 
 if length(varargin) >= 1 && ~isempty(varargin{1})
     Tmax = varargin{1};
@@ -125,6 +133,7 @@ nobs = length(observationdiffs);
 
 % matricise classmeandifss and observationdiffs to use fast matrix
 % multiplication.
+
 classmeandiffstensor = reshape(cell2mat(classmeandiffs), ...
     I, J, nclasses);
 observationdiffstensor = reshape(cell2mat(observationdiffs), ...

--- a/matlab/code/tensor_classification/ManPDA_nd.m
+++ b/matlab/code/tensor_classification/ManPDA_nd.m
@@ -1,0 +1,46 @@
+function [Us, outputs, Ys] = ManPDA_nd(Xs, classes, varargin)
+% [Us, outsmode1, outsmode2, outerwhile, Ys] = ManPDA(Xs, classes, varargin)
+% classes: vector containing class labels. Classes must be sequential
+% numbers starting from one.
+% varargin{1}: lowerdims
+% varargin{2}: Us
+% varargin{3}: opts
+% varargin{4}: usestoppingcrit
+% varargin{5}: maxits
+
+%rng(0)
+% mymat1 = reshape(1:12, 2, 3, 2)
+% mymat2 = reshape(13:24, 2, 3, 2)
+% Xs{1} = mymat1
+% Xs{2} = mymat2
+
+Xsample1 = Xs{1};
+sizeX = size(Xsample1);
+
+
+nmodes = length(sizeX);
+
+Xs_as_concatenated_matrix = cell2mat(Xs);
+Xs_as_matrix = permute(...
+    reshape(Xs_as_concatenated_matrix, [sizeX, length(Xs)]), ...
+    [1:(nmodes-1), nmodes+1, nmodes]);
+% Xs_as_matrix_obs_first_dim = permute(Xs_as_matrix, [nmodes+1, 1:nmodes]);
+% not sure it is advantageous to have the examples over the first dimension
+
+if nargout > 2
+    [Us, outputs, Ys] = ManPDA(Xs, classes, varargin);
+end
+
+if nargout > 1
+    [Us, outputs] = ManPDA(Xs, classes, varargin);
+end
+
+
+if nargout == 1
+    for imode = 1:nmodes
+        Us = ManPDA(Xs, classes, varargin);
+    end
+end
+
+end
+

--- a/matlab/code/tests/test_classification_nd.m
+++ b/matlab/code/tests/test_classification_nd.m
@@ -9,16 +9,16 @@ function test_cell_array_to_nd_array_arbitraryn_modes(testCase)
     testCase.applyFixture(PathFixture('../', 'IncludeSubfolders', true));
 
     n_obs = 5;
-    n_modes = randsample(2:4, 1);
-    obs_dimensions = randsample(1:3, n_modes);
+    n_modes = randsample(2:4, 1, true);
+    obs_dimensions = randsample(1:3, n_modes, true);
     xs_nd_array = zeros([obs_dimensions, n_obs]);
     xs_cell = cell(n_obs);
     S.type = '()';
-    S.subs = [repmat({':'}, 1, n_modes)]
+    subs = repmat({':'}, 1, n_modes);
     
     for iobs = 1:n_obs
+        S.subs = [subs, iobs];
         rand_obs = normrnd(0, 1, obs_dimensions);
-        %xs_nd_array(:,iobs) = rand_obs;
         xs_nd_array = subsasgn(xs_nd_array, S, rand_obs);
         xs_cell{iobs} = rand_obs;
         

--- a/matlab/code/tests/test_classification_nd.m
+++ b/matlab/code/tests/test_classification_nd.m
@@ -9,8 +9,8 @@ function test_cell_array_to_nd_array_arbitraryn_modes(testCase)
     testCase.applyFixture(PathFixture('../', 'IncludeSubfolders', true));
 
     n_obs = 5;
-    n_modes = randsample(2:4, 1, true);
-    obs_dimensions = randsample(1:3, n_modes, true);
+    n_modes = randsample(2:10, 1, true);
+    obs_dimensions = randsample(1:8, n_modes, true);
     xs_nd_array = zeros([obs_dimensions, n_obs]);
     xs_cell = cell(n_obs);
     S.type = '()';

--- a/matlab/code/tests/test_classification_nd.m
+++ b/matlab/code/tests/test_classification_nd.m
@@ -1,0 +1,142 @@
+function tests = test_classification_nd
+    tests = functiontests(localfunctions);
+end
+
+
+
+function test_cell_array_to_nd_array_arbitraryn_modes(testCase)
+    import matlab.unittest.fixtures.PathFixture
+    testCase.applyFixture(PathFixture('../', 'IncludeSubfolders', true));
+
+    n_obs = 5;
+    n_modes = randsample(2:4, 1);
+    obs_dimensions = randsample(1:3, n_modes);
+    xs_nd_array = zeros([obs_dimensions, n_obs]);
+    xs_cell = cell(n_obs);
+    S.type = '()';
+    S.subs = [repmat({':'}, 1, n_modes)]
+    
+    for iobs = 1:n_obs
+        rand_obs = normrnd(0, 1, obs_dimensions);
+        %xs_nd_array(:,iobs) = rand_obs;
+        xs_nd_array = subsasgn(xs_nd_array, S, rand_obs);
+        xs_cell{iobs} = rand_obs;
+        
+    end
+    
+    result = cell_array_to_nd_array(xs_cell);
+    
+    isequal(result, xs_nd_array)
+end
+
+function test_cell_array_to_nd_array_2modes(testCase)
+    import matlab.unittest.fixtures.PathFixture
+    testCase.applyFixture(PathFixture('../', 'IncludeSubfolders', true));
+
+    n_obs = 5;
+    obs_dimensions = [7, 3];
+    xs_nd_array = zeros([obs_dimensions, n_obs]);
+    xs_cell = cell(n_obs);
+    
+    for iobs = 1:n_obs
+        rand_obs = normrnd(0, 1, obs_dimensions);
+        xs_nd_array(:,:,iobs) = rand_obs;
+        xs_cell{iobs} = rand_obs;
+        
+    end
+    
+    result = cell_array_to_nd_array(xs_cell);
+    
+    isequal(result, xs_nd_array)
+end
+
+function test_cell_array_to_nd_array_3modes(testCase)
+    import matlab.unittest.fixtures.PathFixture
+    testCase.applyFixture(PathFixture('../', 'IncludeSubfolders', true));
+
+    n_obs = 5;
+    obs_dimensions = [7, 3, 10];
+    xs_nd_array = zeros([obs_dimensions, n_obs]);
+    xs_cell = cell(n_obs);
+    
+    for iobs = 1:n_obs
+        rand_obs = normrnd(0, 1, obs_dimensions);
+        xs_nd_array(:,:,:,iobs) = rand_obs;
+        xs_cell{iobs} = rand_obs;
+        
+    end
+    
+    result = cell_array_to_nd_array(xs_cell);
+    
+    isequal(result, xs_nd_array)
+end
+
+
+function test_cell_array_to_nd_array_4modes(testCase)
+    import matlab.unittest.fixtures.PathFixture
+    testCase.applyFixture(PathFixture('../', 'IncludeSubfolders', true));
+
+    n_obs = 6;
+    obs_dimensions = [2, 3, 4, 5];
+    xs_nd_array = zeros([obs_dimensions, n_obs]);
+    xs_cell = cell(n_obs);
+    
+    for iobs = 1:n_obs
+        rand_obs = normrnd(0, 1, obs_dimensions);
+        xs_nd_array(:,:,:, :, iobs) = rand_obs;
+        xs_cell{iobs} = rand_obs;
+        
+    end
+    
+    result = cell_array_to_nd_array(xs_cell);
+    
+    isequal(result, xs_nd_array)
+end
+
+function wip_test_cmda_discrimination(testCase)
+    import matlab.unittest.fixtures.PathFixture
+    testCase.applyFixture(PathFixture('../', 'IncludeSubfolders', true));
+    testCase.applyFixture(PathFixture('../../../../matlab_additions/02582nway_models/', 'IncludeSubfolders', true));
+    
+    parafac_structure = false;
+    k = 2;
+    
+    [Xs, ys] = get_simple_data();
+    
+    CMDA(Xs, ys, [], [k, k, k])
+
+    
+    %project_matrices_verify_predictions(testCase, ...
+    %@(Xs, ys) CMDA(Xs, ys, [], [k, k]), ...
+    %@(Xs, Xs_test, ys, ys_test, k, Us) ...
+    %project_and_predict(Xs, Xs_test, ys, ys_test, k, Us, parafac_structure))
+end
+
+
+function [Xs, ys] = get_simple_data()
+    p = 5;
+    q = 7;
+    r = 3;
+    nsamples = 200;
+    [Xs, ys] = get_data(nsamples, [p, q, r]);
+end
+
+function project_matrices_verify_predictions(testCase, ...
+    projection_learning_function, prediction_function, varargin)
+
+    [Xs, ys] = get_simple_data();
+    Xs_test = Xs;
+    ys_test = ys;
+    k = 2;
+    
+    Us = projection_learning_function(Xs, ys);
+    
+    predicted_probabilities = prediction_function(Xs, Xs_test, ys,...
+        ys_test, k, Us);
+    
+    [~, predictions] = max(predicted_probabilities, [], 2);
+    
+    accuracy = mean(predictions == ys);
+    
+    verifyEqual(testCase, accuracy, 1, 'AbsTol', 1e-1)
+end


### PR DESCRIPTION
Adding functionality to convert a cell array containing nd arrays with arbitrarily many modes (but same number of modes and dimensionality for each cell array entry) to an (n+1)d array.